### PR TITLE
Temporarily pin hypothesis on CI

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -41,6 +41,7 @@ jobs:
         fi
         python -m pip install ${GITHUB_WORKSPACE}/array-api-strict
         python -m pip install -r ${GITHUB_WORKSPACE}/array-api-tests/requirements.txt
+        python -m pip install hypothesis==6.97.1
     - name: Run the array API testsuite
       env:
         ARRAY_API_TESTS_MODULE: array_api_strict


### PR DESCRIPTION
This is needed until https://github.com/data-apis/array-api-tests/issues/238 is fixed.