### PR TITLE
Fix asarray(copy=False)

### DIFF
--- a/array-api-tests-xfails.txt
+++ b/array-api-tests-xfails.txt
@@ -1,7 +1,3 @@
-# copy=False is not yet implemented
-# https://github.com/numpy/numpy/pull/25168
-array_api_tests/test_creation_functions.py::test_asarray_arrays
-
 # Some fft tests are currently wrong
 # (https://github.com/data-apis/array-api-tests/issues/231)
 array_api_tests/test_fft.py::test_fft

--- a/array_api_strict/tests/test_creation_functions.py
+++ b/array_api_strict/tests/test_creation_functions.py
@@ -50,19 +50,24 @@ def test_asarray_copy():
     a[0] = 0
     assert all(b[0] == 1)
     assert all(a[0] == 0)
+
     a = asarray([1])
-    b = asarray(a, copy=np._CopyMode.ALWAYS)
-    a[0] = 0
-    assert all(b[0] == 1)
-    assert all(a[0] == 0)
-    a = asarray([1])
-    b = asarray(a, copy=np._CopyMode.NEVER)
+    b = asarray(a, copy=False)
     a[0] = 0
     assert all(b[0] == 0)
-    assert_raises(NotImplementedError, lambda: asarray(a, copy=False))
-    assert_raises(NotImplementedError,
-                  lambda: asarray(a, copy=np._CopyMode.IF_NEEDED))
 
+    a = asarray([1])
+    assert_raises(ValueError, lambda: asarray(a, copy=False, dtype=float64))
+
+    a = asarray([1])
+    b = asarray(a, copy=None)
+    a[0] = 0
+    assert all(b[0] == 0)
+
+    a = asarray([1])
+    b = asarray(a, dtype=float64, copy=None)
+    a[0] = 0
+    assert all(b[0] == 1.0)
 
 def test_arange_errors():
     arange(1, device=CPU_DEVICE)  # Doesn't error


### PR DESCRIPTION
For NumPy 2.0, this is implemented directly. For NumPy 1, we emulate it by checking if asarray() creates a copy or not.

This also removes support for the np._CopyMode enum in asarray(), as this is not portable.

@rgommers I can't remember if there was a good reason that we didn't just emulate copy=False in this way originally (instead, we raised `NotImplementedError`). 