### PR TITLE
Remove fft tests from xfails

### DIFF
--- a/array-api-tests-xfails.txt
+++ b/array-api-tests-xfails.txt
@@ -2,19 +2,6 @@
 # https://github.com/numpy/numpy/pull/25168
 array_api_tests/test_creation_functions.py::test_asarray_arrays
 
-# Some fft tests are currently wrong
-# (https://github.com/data-apis/array-api-tests/issues/231)
-array_api_tests/test_fft.py::test_fft
-array_api_tests/test_fft.py::test_ifft
-array_api_tests/test_fft.py::test_fftn
-array_api_tests/test_fft.py::test_ifftn
-array_api_tests/test_fft.py::test_rfft
-array_api_tests/test_fft.py::test_irfft
-array_api_tests/test_fft.py::test_rfftn
-array_api_tests/test_fft.py::test_irfftn
-array_api_tests/test_fft.py::test_hfft
-array_api_tests/test_fft.py::test_ihfft
-
 # Known special case issue in NumPy. Not worth working around here
 # https://github.com/numpy/numpy/issues/21213
 array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -infinity and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +infinity]


### PR DESCRIPTION
The test suite is updated so that these tests no longer fail.