### PR TITLE
Update api_version argument to __array_namespace__

### DIFF
--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import operator
 from enum import IntEnum
+import warnings
+
 from ._creation_functions import asarray
 from ._dtypes import (
     _DType,
@@ -480,8 +482,10 @@ class Array:
     def __array_namespace__(
         self: Array, /, *, api_version: Optional[str] = None
     ) -> types.ModuleType:
-        if api_version is not None and not api_version.startswith("2021."):
+        if api_version is not None and api_version not in ["2021.12", "2022.12"]:
             raise ValueError(f"Unrecognized array API version: {api_version!r}")
+        if api_version == "2021.12":
+            warnings.warn("The 2021.12 version of the array API specification was requested but the returned namespace is actually version 2022.12")
         import array_api_strict
         return array_api_strict
 

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -23,7 +23,7 @@ from .._dtypes import (
     uint64,
     bool as bool_,
 )
-
+import array_api_strict
 
 def test_validate_index():
     # The indexing tests in the official array API test suite test that the
@@ -398,3 +398,13 @@ def test_array_keys_use_private_array():
     key = ones((0, 0), dtype=bool_)
     with pytest.raises(IndexError):
         a[key]
+
+def test_array_namespace():
+    a = ones((3, 3))
+    assert a.__array_namespace__() == array_api_strict
+    assert a.__array_namespace__(api_version=None) is array_api_strict
+    assert a.__array_namespace__(api_version="2022.12") is array_api_strict
+    with pytest.warns(UserWarning):
+        assert a.__array_namespace__(api_version="2021.12") is array_api_strict
+    pytest.raises(ValueError, lambda: a.__array_namespace__(api_version="2021.11"))
+    pytest.raises(ValueError, lambda: a.__array_namespace__(api_version="2023.12"))


### PR DESCRIPTION
- Allow 2022.12
- Warn on 2021.12
- Be more strict about only accepting those two versions