### PR TITLE
Don't try to run the publish step unless the commit is a tag

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -69,7 +69,7 @@ jobs:
 
   publish:
     name: Publish Python distribution to (Test)PyPI
-    if: github.event_name != 'pull_request' && github.repository == 'data-apis/array-api-strict'
+    if: github.event_name != 'pull_request' && github.repository == 'data-apis/array-api-strict' && github.ref_type == 'tag'
     needs: build
     runs-on: ubuntu-latest
     # Mandatory for publishing with a trusted publisher


### PR DESCRIPTION
This prevents this workflow from failing on every commit in main.