### PR TITLE
Revert "Allow any combination of real dtypes in comparisons"

### DIFF
--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -152,14 +152,7 @@ class Array:
     # spec in places where it either deviates from or is more strict than
     # NumPy behavior
 
-    def _check_allowed_dtypes(
-            self,
-            other: bool | int | float | Array,
-            dtype_category: str,
-            op: str,
-            *,
-            check_promotion: bool = True,
-    ) -> Array:
+    def _check_allowed_dtypes(self, other: bool | int | float | Array, dtype_category: str, op: str) -> Array:
         """
         Helper function for operators to only allow specific input dtypes
 
@@ -183,8 +176,7 @@ class Array:
         # This will raise TypeError for type combinations that are not allowed
         # to promote in the spec (even if the NumPy array operator would
         # promote them).
-        if check_promotion:
-            res_dtype = _result_type(self.dtype, other.dtype)
+        res_dtype = _result_type(self.dtype, other.dtype)
         if op.startswith("__i"):
             # Note: NumPy will allow in-place operators in some cases where
             # the type promoted operator does not match the left-hand side
@@ -578,7 +570,7 @@ class Array:
         """
         # Even though "all" dtypes are allowed, we still require them to be
         # promotable with each other.
-        other = self._check_allowed_dtypes(other, "all", "__eq__", check_promotion=False)
+        other = self._check_allowed_dtypes(other, "all", "__eq__")
         if other is NotImplemented:
             return other
         self, other = self._normalize_two_args(self, other)
@@ -612,7 +604,7 @@ class Array:
         """
         Performs the operation __ge__.
         """
-        other = self._check_allowed_dtypes(other, "real numeric", "__ge__", check_promotion=False)
+        other = self._check_allowed_dtypes(other, "real numeric", "__ge__")
         if other is NotImplemented:
             return other
         self, other = self._normalize_two_args(self, other)
@@ -646,7 +638,7 @@ class Array:
         """
         Performs the operation __gt__.
         """
-        other = self._check_allowed_dtypes(other, "real numeric", "__gt__", check_promotion=False)
+        other = self._check_allowed_dtypes(other, "real numeric", "__gt__")
         if other is NotImplemented:
             return other
         self, other = self._normalize_two_args(self, other)
@@ -700,7 +692,7 @@ class Array:
         """
         Performs the operation __le__.
         """
-        other = self._check_allowed_dtypes(other, "real numeric", "__le__", check_promotion=False)
+        other = self._check_allowed_dtypes(other, "real numeric", "__le__")
         if other is NotImplemented:
             return other
         self, other = self._normalize_two_args(self, other)
@@ -722,7 +714,7 @@ class Array:
         """
         Performs the operation __lt__.
         """
-        other = self._check_allowed_dtypes(other, "real numeric", "__lt__", check_promotion=False)
+        other = self._check_allowed_dtypes(other, "real numeric", "__lt__")
         if other is NotImplemented:
             return other
         self, other = self._normalize_two_args(self, other)
@@ -767,7 +759,7 @@ class Array:
         """
         Performs the operation __ne__.
         """
-        other = self._check_allowed_dtypes(other, "all", "__ne__", check_promotion=False)
+        other = self._check_allowed_dtypes(other, "all", "__ne__")
         if other is NotImplemented:
             return other
         self, other = self._normalize_two_args(self, other)

--- a/array_api_strict/_elementwise_functions.py
+++ b/array_api_strict/_elementwise_functions.py
@@ -375,6 +375,8 @@ def equal(x1: Array, x2: Array, /) -> Array:
 
     See its docstring for more information.
     """
+    # Call result type here just to raise on disallowed type combinations
+    _result_type(x1.dtype, x2.dtype)
     x1, x2 = Array._normalize_two_args(x1, x2)
     return Array._new(np.equal(x1._array, x2._array))
 
@@ -437,6 +439,8 @@ def greater(x1: Array, x2: Array, /) -> Array:
     """
     if x1.dtype not in _real_numeric_dtypes or x2.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in greater")
+    # Call result type here just to raise on disallowed type combinations
+    _result_type(x1.dtype, x2.dtype)
     x1, x2 = Array._normalize_two_args(x1, x2)
     return Array._new(np.greater(x1._array, x2._array))
 
@@ -449,6 +453,8 @@ def greater_equal(x1: Array, x2: Array, /) -> Array:
     """
     if x1.dtype not in _real_numeric_dtypes or x2.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in greater_equal")
+    # Call result type here just to raise on disallowed type combinations
+    _result_type(x1.dtype, x2.dtype)
     x1, x2 = Array._normalize_two_args(x1, x2)
     return Array._new(np.greater_equal(x1._array, x2._array))
 
@@ -518,6 +524,8 @@ def less(x1: Array, x2: Array, /) -> Array:
     """
     if x1.dtype not in _real_numeric_dtypes or x2.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in less")
+    # Call result type here just to raise on disallowed type combinations
+    _result_type(x1.dtype, x2.dtype)
     x1, x2 = Array._normalize_two_args(x1, x2)
     return Array._new(np.less(x1._array, x2._array))
 
@@ -530,6 +538,8 @@ def less_equal(x1: Array, x2: Array, /) -> Array:
     """
     if x1.dtype not in _real_numeric_dtypes or x2.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in less_equal")
+    # Call result type here just to raise on disallowed type combinations
+    _result_type(x1.dtype, x2.dtype)
     x1, x2 = Array._normalize_two_args(x1, x2)
     return Array._new(np.less_equal(x1._array, x2._array))
 
@@ -705,6 +715,8 @@ def not_equal(x1: Array, x2: Array, /) -> Array:
 
     See its docstring for more information.
     """
+    # Call result type here just to raise on disallowed type combinations
+    _result_type(x1.dtype, x2.dtype)
     x1, x2 = Array._normalize_two_args(x1, x2)
     return Array._new(np.not_equal(x1._array, x2._array))
 

--- a/array_api_strict/tests/test_elementwise_functions.py
+++ b/array_api_strict/tests/test_elementwise_functions.py
@@ -1,6 +1,6 @@
 from inspect import getfullargspec, getmodule
 
-from .test_array_object import assert_raises
+from numpy.testing import assert_raises
 
 from .. import asarray, _elementwise_functions
 from .._elementwise_functions import bitwise_left_shift, bitwise_right_shift
@@ -9,11 +9,6 @@ from .._dtypes import (
     _boolean_dtypes,
     _floating_dtypes,
     _integer_dtypes,
-    int8,
-    int16,
-    int32,
-    int64,
-    uint64,
 )
 from .._flags import set_array_api_strict_flags
 
@@ -91,15 +86,6 @@ elementwise_function_input_types = {
     "trunc": "real numeric",
 }
 
-comparison_functions = [
-    'equal',
-    'greater',
-    'greater_equal',
-    'less',
-    'less_equal',
-    'not_equal',
-]
-
 def test_missing_functions():
     # Ensure the above dictionary is complete.
     import array_api_strict._elementwise_functions as mod
@@ -129,20 +115,8 @@ def test_function_types():
             func = getattr(_elementwise_functions, func_name)
             if nargs(func) == 2:
                 for y in _array_vals():
-                    # Disallow dtypes that aren't type promotable
-                    if (func_name not in comparison_functions and
-                        (x.dtype == uint64 and y.dtype in [int8, int16, int32, int64]
-                         or y.dtype == uint64 and x.dtype in [int8, int16, int32, int64]
-                         or x.dtype in _integer_dtypes and y.dtype not in _integer_dtypes
-                         or y.dtype in _integer_dtypes and x.dtype not in _integer_dtypes
-                         or x.dtype in _boolean_dtypes and y.dtype not in _boolean_dtypes
-                         or y.dtype in _boolean_dtypes and x.dtype not in _boolean_dtypes
-                         or x.dtype in _floating_dtypes and y.dtype not in _floating_dtypes
-                         or y.dtype in _floating_dtypes and x.dtype not in _floating_dtypes
-                         )):
-                        assert_raises(TypeError, lambda: func(x, y), (func_name, x, y))
                     if x.dtype not in dtypes or y.dtype not in dtypes:
-                        assert_raises(TypeError, lambda: func(x, y), (func_name, x, y))
+                        assert_raises(TypeError, lambda: func(x, y))
             else:
                 if x.dtype not in dtypes:
                     assert_raises(TypeError, lambda: func(x))

--- a/array_api_strict/tests/test_elementwise_functions.py
+++ b/array_api_strict/tests/test_elementwise_functions.py
@@ -9,6 +9,11 @@ from .._dtypes import (
     _boolean_dtypes,
     _floating_dtypes,
     _integer_dtypes,
+    int8,
+    int16,
+    int32,
+    int64,
+    uint64,
 )
 from .._flags import set_array_api_strict_flags
 
@@ -115,6 +120,17 @@ def test_function_types():
             func = getattr(_elementwise_functions, func_name)
             if nargs(func) == 2:
                 for y in _array_vals():
+                    # Disallow dtypes that aren't type promotable
+                    if (x.dtype == uint64 and y.dtype in [int8, int16, int32, int64]
+                         or y.dtype == uint64 and x.dtype in [int8, int16, int32, int64]
+                         or x.dtype in _integer_dtypes and y.dtype not in _integer_dtypes
+                         or y.dtype in _integer_dtypes and x.dtype not in _integer_dtypes
+                         or x.dtype in _boolean_dtypes and y.dtype not in _boolean_dtypes
+                         or y.dtype in _boolean_dtypes and x.dtype not in _boolean_dtypes
+                         or x.dtype in _floating_dtypes and y.dtype not in _floating_dtypes
+                         or y.dtype in _floating_dtypes and x.dtype not in _floating_dtypes
+                         ):
+                        assert_raises(TypeError, lambda: func(x, y))
                     if x.dtype not in dtypes or y.dtype not in dtypes:
                         assert_raises(TypeError, lambda: func(x, y))
             else:


### PR DESCRIPTION
Reverts data-apis/array-api-strict#53. The standard is likely going to change to make this undefined. See https://github.com/data-apis/array-api/pull/822.