### PR TITLE
Fix issue with repeat()

### DIFF
--- a/array_api_strict/_manipulation_functions.py
+++ b/array_api_strict/_manipulation_functions.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from ._array_object import Array
 from ._creation_functions import asarray
-from ._data_type_functions import result_type
-from ._dtypes import _integer_dtypes
+from ._data_type_functions import astype, result_type
+from ._dtypes import _integer_dtypes, int64, uint64
 from ._flags import requires_api_version, get_array_api_strict_flags
 
 from typing import TYPE_CHECKING
@@ -94,7 +94,13 @@ def repeat(
     else:
         raise TypeError("repeats must be an int or array")
 
-    return Array._new(np.repeat(x._array, repeats, axis=axis))
+    if repeats.dtype == uint64:
+        # NumPy does not allow uint64 because can't be cast down to x.dtype
+        # with 'safe' casting. However, repeats values larger than 2**63 are
+        # infeasable, and even if they are present by mistake, this will
+        # lead to underflow and an error.
+        repeats = astype(repeats, int64)
+    return Array._new(np.repeat(x._array, repeats._array, axis=axis))
 
 # Note: the optional argument is called 'shape', not 'newshape'
 def reshape(x: Array,


### PR DESCRIPTION
NumPy does not allow repeats to be uint64 because it refuses to downcast it. Technically it worked before because we implement __array__ and repeat does manually cast in that case. I'm not really sure we should be supporting __array__ actually.