### PR TITLE
Remove __array__

### DIFF
--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -160,8 +160,8 @@ class Array:
         # We have to allow this to be internally enabled as there's no other
         # easy way to parse a list of Array objects in asarray().
         if _allow_array:
-        if self._device != CPU_DEVICE:
-            raise RuntimeError(f"Can not convert array on the '{self._device}' device to a Numpy array.")
+            if self._device != CPU_DEVICE:
+                raise RuntimeError(f"Can not convert array on the '{self._device}' device to a Numpy array.")
             # copy keyword is new in 2.0.0; for older versions don't use it
             # retry without that keyword.
             if np.__version__[0] < '2':

--- a/array_api_strict/_creation_functions.py
+++ b/array_api_strict/_creation_functions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 if TYPE_CHECKING:
@@ -16,6 +16,19 @@ from ._flags import get_array_api_strict_flags
 
 import numpy as np
 
+@contextmanager
+def allow_array():
+    """
+    Temporarily enable Array.__array__. This is needed for np.array to parse
+    list of lists of Array objects.
+    """
+    from . import _array_object
+    original_value = _array_object._allow_array
+    try:
+        _array_object._allow_array = True
+        yield
+    finally:
+        _array_object._allow_array = original_value
 
 def _check_valid_dtype(dtype):
     # Note: Only spelling dtypes as the dtype objects is supported.
@@ -94,7 +107,8 @@ def asarray(
         # Give a better error message in this case. NumPy would convert this
         # to an object array. TODO: This won't handle large integers in lists.
         raise OverflowError("Integer out of bounds for array dtypes")
-    res = np.array(obj, dtype=_np_dtype, copy=copy)
+    with allow_array():
+        res = np.array(obj, dtype=_np_dtype, copy=copy)
     return Array._new(res)
 
 

--- a/array_api_strict/_linalg.py
+++ b/array_api_strict/_linalg.py
@@ -267,6 +267,8 @@ def pinv(x: Array, /, *, rtol: Optional[Union[float, Array]] = None) -> Array:
     # default tolerance by max(M, N).
     if rtol is None:
         rtol = max(x.shape[-2:]) * finfo(x.dtype).eps
+    if isinstance(rtol, Array):
+        rtol = rtol._array
     return Array._new(np.linalg.pinv(x._array, rcond=rtol), device=x.device)
 
 @requires_extension('linalg')

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -353,14 +353,17 @@ def test_array_properties():
 
 def test_array_conversion():
     # Check that arrays on the CPU device can be converted to NumPy
-    # but arrays on other devices can't
+    # but arrays on other devices can't. Note this is testing the logic in
+    # __array__, which is only used in asarray when converting lists of
+    # arrays.
     a = ones((2, 3))
-    np.asarray(a)
+    asarray([a])
 
     for device in ("device1", "device2"):
         a = ones((2, 3), device=array_api_strict.Device(device))
         with pytest.raises(RuntimeError, match="Can not convert array"):
-            np.asarray(a)
+            asarray([a])
+
 def test_allow_newaxis():
     a = ones(5)
     indexed_a = a[None, :]

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -342,13 +342,6 @@ def test_array_properties():
     assert isinstance(b.mT, Array)
     assert b.mT.shape == (3, 2)
 
-def test___array__():
-    a = ones((2, 3), dtype=int16)
-    assert np.asarray(a) is a._array
-    b = np.asarray(a, dtype=np.float64)
-    assert np.all(np.equal(b, np.ones((2, 3), dtype=np.float64)))
-    assert b.dtype == np.float64
-
 def test_allow_newaxis():
     a = ones(5)
     indexed_a = a[None, :]

--- a/array_api_strict/tests/test_creation_functions.py
+++ b/array_api_strict/tests/test_creation_functions.py
@@ -22,7 +22,7 @@ from .._creation_functions import (
     zeros,
     zeros_like,
 )
-from .._dtypes import float32, float64
+from .._dtypes import int16, float32, float64
 from .._array_object import Array, CPU_DEVICE
 from .._flags import set_array_api_strict_flags
 
@@ -96,6 +96,19 @@ def test_asarray_copy():
     assert isinstance(b, Array)
     a[0] = 0
     assert all(b[0] == 0)
+
+def test_asarray_list_of_lists():
+    a = asarray(1, dtype=int16)
+    b = asarray([1], dtype=int16)
+    res = asarray([a, a])
+    assert res.shape == (2,)
+    assert res.dtype == int16
+    assert all(res == asarray([1, 1]))
+
+    res = asarray([b, b])
+    assert res.shape == (2, 1)
+    assert res.dtype == int16
+    assert all(res == asarray([[1], [1]]))
 
 def test_arange_errors():
     arange(1, device=CPU_DEVICE)  # Doesn't error


### PR DESCRIPTION
This makes it raise an exception, since it isn't supported by the standard (if
we just leave it unimplemented, then np.asarray() returns an object dtype
array, which is not good).

There is one issue here from the test suite, which is that this breaks the
logic in asarray() for converting lists of array_api_strict 0-D arrays. I'm
not yet sure what to do about that.

Fixes https://github.com/data-apis/array-api-strict/issues/67.

This is built on #68, which can and should be merged separately (it isn't controversial). 