### PR TITLE
Add support for scalar arguments to xp.where

### DIFF
--- a/array_api_strict/_searching_functions.py
+++ b/array_api_strict/_searching_functions.py
@@ -89,7 +89,7 @@ def where(condition: Array, x1: bool | int | float | Array, x2: bool | int | flo
     _result_type(x1.dtype, x2.dtype)
 
     if len({a.device for a in (condition, x1, x2)}) > 1:
-        raise ValueError("where inputs must all be on the same device")
+        raise ValueError("Inputs to `where` must all use the same device")
 
     x1, x2 = Array._normalize_two_args(x1, x2)
     return Array._new(np.where(condition._array, x1._array, x2._array), device=x1.device)

--- a/array_api_strict/tests/test_searching_functions.py
+++ b/array_api_strict/tests/test_searching_functions.py
@@ -14,7 +14,12 @@ def test_where_with_scalars():
         xp.where(x == 1, 42, 44)
 
     # Versions after 2023.12 support scalar arguments
-    with ArrayAPIStrictFlags(api_version=draft_version):
+    with (pytest.warns(
+              UserWarning,
+              match="The 2024.12 version of the array API specification is in draft status"
+          ),
+          ArrayAPIStrictFlags(api_version=draft_version),
+        ):
         x_where = xp.where(x == 1, 42, 44)
 
         expected = xp.asarray([42, 44, 44, 42])

--- a/array_api_strict/tests/test_searching_functions.py
+++ b/array_api_strict/tests/test_searching_functions.py
@@ -3,7 +3,7 @@ import pytest
 import array_api_strict as xp
 
 from array_api_strict import ArrayAPIStrictFlags
-from array_api_strict._flags import next_supported_version
+from array_api_strict._flags import draft_version
 
 
 def test_where_with_scalars():
@@ -14,7 +14,7 @@ def test_where_with_scalars():
         xp.where(x == 1, 42, 44)
 
     # Versions after 2023.12 support scalar arguments
-    with ArrayAPIStrictFlags(api_version=next_supported_version):
+    with ArrayAPIStrictFlags(api_version=draft_version):
         x_where = xp.where(x == 1, 42, 44)
 
         expected = xp.asarray([42, 44, 44, 42])

--- a/array_api_strict/tests/test_searching_functions.py
+++ b/array_api_strict/tests/test_searching_functions.py
@@ -1,0 +1,21 @@
+import pytest
+
+import array_api_strict as xp
+
+from array_api_strict import ArrayAPIStrictFlags
+from array_api_strict._flags import next_supported_version
+
+
+def test_where_with_scalars():
+    x = xp.asarray([1, 2, 3, 1])
+
+    # Versions up to and including 2023.12 don't support scalar arguments
+    with pytest.raises(AttributeError, match="object has no attribute 'dtype'"):
+        xp.where(x == 1, 42, 44)
+
+    # Versions after 2023.12 support scalar arguments
+    with ArrayAPIStrictFlags(api_version=next_supported_version):
+        x_where = xp.where(x == 1, 42, 44)
+
+        expected = xp.asarray([42, 44, 44, 42])
+        assert xp.all(x_where == expected)


### PR DESCRIPTION
This is related to https://github.com/data-apis/array-api/issues/807

This only adds support for scalars to `where()`. If the second or third argument is a scalar it is turned into an array on the same device as `condition`.

I added `2024.12` as `next_supported_version`. This means we can use it in the tests. Not sure if we use some kind of dummy value instead of 2024.12?