### PR TITLE
ENH: prohibit astype(complex, not complex)

### DIFF
--- a/array_api_strict/_data_type_functions.py
+++ b/array_api_strict/_data_type_functions.py
@@ -42,6 +42,13 @@ def astype(
 
     if not copy and dtype == x.dtype:
         return x
+
+    if isdtype(x.dtype, 'complex floating') and not isdtype(dtype, 'complex floating'):
+        raise TypeError(
+            f'The Array API standard stipulates that casting {x.dtype} to {dtype} should not be permitted. '
+             'array-api-strict thus prohibits this conversion.'
+        )
+
     return Array._new(x._array.astype(dtype=dtype._np_dtype, copy=copy), device=device)
 
 


### PR DESCRIPTION
as discussed in https://github.com/data-apis/array-api-tests/pull/311 :

the spec stipulates that (https://data-apis.org/array-api/latest/API_specification/generated/array_api.astype.html#astype)

> Casting a complex floating-point array to a real-valued data type should not be permitted.

Thus error out here and avoid testing `astype(complex, not complex)`  it in `-tests`.