### PR TITLE
MAINT: make __str__ less ambiguous

### DIFF
--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -126,12 +126,6 @@ class Array:
     # These functions are not required by the spec, but are implemented for
     # the sake of usability.
 
-    def __str__(self: Array, /) -> str:
-        """
-        Performs the operation __str__.
-        """
-        return self._array.__str__().replace("array", "Array")
-
     def __repr__(self: Array, /) -> str:
         """
         Performs the operation __repr__.
@@ -148,6 +142,8 @@ class Array:
             prefix = "Array("
             mid = np.array2string(self._array, separator=', ', prefix=prefix, suffix=suffix)
         return prefix + mid + suffix
+
+    __str__ = __repr__
 
     # In the future, _allow_array will be set to False, which will disallow
     # __array__. This means calling `np.func()` on an array_api_strict array


### PR DESCRIPTION
For 0D arrays, `__str__` used to look confusingly like a scalar, make it clearly an array instead.

Before:

```
In [1]: import array_api_strict as xp

In [2]: x = xp.asarray(3)

In [3]: print(x)     # looks like a scalar!
3

In [4]: x.__class__
Out[4]: array_api_strict._array_object.Array

In [5]: x
Out[5]: Array(3, dtype=array_api_strict.int64)
```

This PR:

```
In [1]: import array_api_strict as xp

In [2]: x = xp.asarray(3)

In [3]: print(x)
Array(3, dtype=array_api_strict.int64)

In [4]: x
Out[4]: Array(3, dtype=array_api_strict.int64)
```