### PR TITLE
ENH: rm __array__, add __buffer__

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-        numpy-version: ['1.26', 'dev']
+        python-version: ['3.12', '3.13']
+        numpy-version: ['1.26', '2.2', 'dev']
         exclude:
           - python-version: '3.13'
             numpy-version: '1.26'
@@ -38,7 +38,7 @@ jobs:
         if [[ "${{ matrix.numpy-version }}" == "dev" ]]; then
           python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy;
         else
-          python -m pip install 'numpy>=1.26,<2.0';
+          python -m pip install 'numpy=='${{ matrix.numpy-version }};
         fi
         python -m pip install ${GITHUB_WORKSPACE}/array-api-strict
         python -m pip install -r ${GITHUB_WORKSPACE}/array-api-tests/requirements.txt

--- a/array_api_strict/_creation_functions.py
+++ b/array_api_strict/_creation_functions.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Generator
-from contextlib import contextmanager
 from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
@@ -24,21 +22,6 @@ class Undef(Enum):
 
 
 _undef = Undef.UNDEF
-
-
-@contextmanager
-def allow_array() -> Generator[None]:
-    """
-    Temporarily enable Array.__array__. This is needed for np.array to parse
-    list of lists of Array objects.
-    """
-    from . import _array_object
-    original_value = _array_object._allow_array
-    try:
-        _array_object._allow_array = True
-        yield
-    finally:
-        _array_object._allow_array = original_value
 
 
 def _check_valid_dtype(dtype: DType | None) -> None:
@@ -123,8 +106,8 @@ def asarray(
         # Give a better error message in this case. NumPy would convert this
         # to an object array. TODO: This won't handle large integers in lists.
         raise OverflowError("Integer out of bounds for array dtypes")
-    with allow_array():
-        res = np.array(obj, dtype=_np_dtype, copy=copy)
+
+    res = np.array(obj, dtype=_np_dtype, copy=copy)
     return Array._new(res, device=device)
 
 


### PR DESCRIPTION
Try getting rid of `__array__`, replace with the buffer protocol's `__buffer__`.

cross-ref https://github.com/data-apis/array-api-strict/issues/67, https://github.com/data-apis/array-api-strict/pull/69

This does not seem to fix gh-102. `scipy` tests pass locally. 
Replacing `__array__` with `__buffer__` makes code marginally simpler. Effectively bumps the python requirement to 3.12+ though.
So maybe this is a temp solution until `dlpack` matures. 
`¯\_(ツ)_/¯`

