### PR TITLE
Define complex scalar <op> float array

### DIFF
--- a/array_api_strict/_dtypes.py
+++ b/array_api_strict/_dtypes.py
@@ -126,6 +126,7 @@ _dtype_categories = {
     "floating-point": _floating_dtypes,
 }
 
+_real_to_complex_map = {float32: complex64, float64: complex128}
 
 # Note: the spec defines a restricted type promotion table compared to NumPy.
 # In particular, cross-kind promotions like integer + float or boolean +

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -108,6 +108,14 @@ def _check_op_array_scalar(dtypes, a, s, func, func_name, BIG_INT=BIG_INT):
     # - a Python int or float for real floating-point array dtypes
     # - a Python int, float, or complex for complex floating-point array dtypes
 
+    # an exception: complex scalar <op> floating array
+    scalar_types_for_float = [float, int]
+    if not (func_name.startswith("__i")
+            or (func_name in ["__floordiv__", "__rfloordiv__", "__mod__", "__rmod__"]
+                and type(s) == complex)
+    ):
+        scalar_types_for_float += [complex]
+
     if ((dtypes == "all"
          or dtypes == "numeric" and a.dtype in _numeric_dtypes
          or dtypes == "real numeric" and a.dtype in _real_numeric_dtypes
@@ -121,7 +129,7 @@ def _check_op_array_scalar(dtypes, a, s, func, func_name, BIG_INT=BIG_INT):
         # isinstance here.
         and (a.dtype in _boolean_dtypes and type(s) == bool
              or a.dtype in _integer_dtypes and type(s) == int
-             or a.dtype in _real_floating_dtypes and type(s) in [float, int]
+             or a.dtype in _real_floating_dtypes and type(s) in scalar_types_for_float
              or a.dtype in _complex_floating_dtypes and type(s) in [complex, float, int]
         )):
         if a.dtype in _integer_dtypes and s == BIG_INT:

--- a/array_api_strict/tests/test_elementwise_functions.py
+++ b/array_api_strict/tests/test_elementwise_functions.py
@@ -233,15 +233,25 @@ def test_scalars():
         if nargs(func) != 2:
             continue
 
+        nocomplex = [
+            'atan2', 'copysign', 'floor_divide', 'hypot', 'logaddexp',  'nextafter',
+            'remainder',
+            'greater', 'less', 'greater_equal', 'less_equal', 'maximum', 'minimum',
+        ]
+
         for s in [1, 1.0, 1j, BIG_INT, False]:
             for a in _array_vals():
                 for func1 in [lambda s: func(a, s), lambda s: func(s, a)]:
-                    allowed = _check_op_array_scalar(dtypes, a, s, func1, func_name)
+
+                    if func_name in nocomplex and type(s) == complex:
+                        allowed = False
+                    else:
+                        allowed = _check_op_array_scalar(dtypes, a, s, func1, func_name)
 
                     # only check `func(array, scalar) == `func(array, array)` if
                     # the former is legal under the promotion rules
                     if allowed:
-                        conv_scalar = asarray(s, dtype=a.dtype)
+                        conv_scalar = a._promote_scalar(s)
 
                         with suppress_warnings() as sup:
                             # ignore warnings from pow(BIG_INT)


### PR DESCRIPTION
This is a companion to https://github.com/data-apis/array-api/pull/871

The volume of workarounds to make tests pass is not bad bad bad, but is probably worth a longer look.
Maybe `array._promote_scalar` needs to grow a flag to tell whether mixing complex and floats is allowed for a specific caller.