### PR TITLE
MAINT: block axis=None in squeeze

### DIFF
--- a/array_api_strict/_manipulation_functions.py
+++ b/array_api_strict/_manipulation_functions.py
@@ -153,6 +153,11 @@ def squeeze(x: Array, /, axis: Union[int, Tuple[int, ...]]) -> Array:
 
     See its docstring for more information.
     """
+    if axis is None:
+        raise ValueError(
+            "squeeze(..., axis=None is not supported. See "
+            "https://github.com/data-apis/array-api/pull/100 for a discussion."
+        )
     return Array._new(np.squeeze(x._array, axis=axis), device=x.device)
 
 


### PR DESCRIPTION
closes https://github.com/data-apis/array-api-strict/issues/62

Not having `axis=None` is, in fact, a deliberate decision: https://github.com/data-apis/array-api/issues/892