### PR TITLE
CI: update the workflows

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         numpy-version: ['1.26', 'dev']
         exclude:
-          - python-version: '3.8'
-            numpy-version: 'dev'
+          - python-version: '3.13'
+            numpy-version: '1.26'
 
     steps:
     - name: Checkout array-api-strict

--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -3,8 +3,8 @@ name: Array API Tests
 on: [push, pull_request]
 
 env:
-  PYTEST_ARGS: "-v -rxXfE --ci --hypothesis-disable-deadline --max-examples 200"
-  API_VERSIONS: "2022.12 2023.12 2024.12"
+  PYTEST_ARGS: "-v -rxXfE --hypothesis-disable-deadline --max-examples 200"
+  API_VERSIONS: "2023.12 2024.12"
 
 jobs:
   array-api-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         numpy-version: ['1.26', 'dev']
         exclude:
-          - python-version: '3.8'
-            numpy-version: 'dev'
+          - python-version: '3.13'
+            numpy-version: '1.26'
       fail-fast: true
     steps:
       - uses: actions/checkout@v4

--- a/array-api-tests-xfails.txt
+++ b/array-api-tests-xfails.txt
@@ -26,3 +26,6 @@ array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and
 # The test suite is incorrectly checking sums that have loss of significance
 # (https://github.com/data-apis/array-api-tests/issues/168)
 array_api_tests/test_statistical_functions.py::test_sum
+
+array_api_tests/test_special_cases.py::test_nan_propagation[cumulative_prod]
+


### PR DESCRIPTION
- stop testing python 3.9
- start testing python 3.13
- actually test Array API revision 2024.12
- stop testing 2022.12 revision (only test 2023.12 and 2024.12)