### PR TITLE
BUG: fix tuple array indexing

### DIFF
--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -727,7 +727,14 @@ class Array:
         if isinstance(key, Array):
             key = (key,)
         np_key = key
+        devices = {self.device}
         if isinstance(key, tuple):
+            devices.update([subkey.device for subkey in key])
+            if len(devices) > 1:
+                raise ValueError(
+                    "Array indexing is only allowed when array to be indexed and all "
+                    "indexing arrays are on the same device."
+                )
             # Indexing self._array with array_api_strict arrays can be erroneous
             # e.g., when using non-default device
             np_key = tuple(

--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -729,7 +729,9 @@ class Array:
         np_key = key
         devices = {self.device}
         if isinstance(key, tuple):
-            devices.update([subkey.device for subkey in key])
+            devices.update(
+                [subkey.device for subkey in key if hasattr(subkey, "device")]
+            )
             if len(devices) > 1:
                 raise ValueError(
                     "Array indexing is only allowed when array to be indexed and all "

--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -698,8 +698,13 @@ class Array:
         # docstring of _validate_index
         self._validate_index(key)
         if isinstance(key, Array):
+            key = (key,)
+        if isinstance(key, tuple):
             # Indexing self._array with array_api_strict arrays can be erroneous
-            key = key._array
+            # e.g., when using non-default device
+            key = tuple(
+                subkey._array if isinstance(subkey, Array) else subkey for subkey in key
+            )
         res = self._array.__getitem__(key)
         return self._new(res, device=self.device)
 

--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -733,7 +733,7 @@ class Array:
             np_key = tuple(
                 subkey._array if isinstance(subkey, Array) else subkey for subkey in key
             )
-        res = self._array.__getitem__(key)
+        res = self._array.__getitem__(np_key)
         return self._new(res, device=self.device)
 
     def __gt__(self, other: Array | int | float, /) -> Array:

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -102,7 +102,7 @@ def test_validate_index():
 
 
 @pytest.mark.parametrize("device", [None, "CPU_DEVICE", "device1", "device2"])
-def test_indexing_arrays():
+def test_indexing_arrays(device):
     # indexing with 1D integer arrays and mixes of integers and 1D integer are allowed
     device = None if device is None else Device(device)
 

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -101,10 +101,10 @@ def test_validate_index():
     assert_raises(IndexError, lambda: a[idx])
 
 
-# @pytest.mark.parametrize("device", ["CPU_DEVICE", "device1", "device2"])
-def test_indexing_arrays(device='device1'):
+@pytest.mark.parametrize("device", [None, "CPU_DEVICE", "device1", "device2"])
+def test_indexing_arrays():
     # indexing with 1D integer arrays and mixes of integers and 1D integer are allowed
-    device = Device(device)
+    device = None if device is None else Device(device)
 
     # 1D array
     a = arange(5)


### PR DESCRIPTION
closes #134

When indexing with tuple containing `Array`s, convert to numpy array (`self._array`) first. Not doing so results in e.g. "Can not convert array on the 'array_api_strict.Device('device1')' device to a Numpy array." error

Parametrized indexing tests for all devices. Also added shape checks in test because while working on this PR, I created a bug that was not picked up by the test in the current format as the bug also affected the loop arrays.

cc @ev-br 