### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -16,11 +16,10 @@ of ndarray.
 from __future__ import annotations
 
 import operator
-import sys
 from collections.abc import Iterator
 from enum import IntEnum
-from types import ModuleType
-from typing import TYPE_CHECKING, Any, Final, Literal, SupportsIndex
+from types import EllipsisType, ModuleType
+from typing import Any, Final, Literal, SupportsIndex
 
 import numpy as np
 import numpy.typing as npt
@@ -42,13 +41,6 @@ from ._dtypes import (
 )
 from ._flags import get_array_api_strict_flags, set_array_api_strict_flags
 from ._typing import PyCapsule
-
-if sys.version_info >= (3, 10):
-    from types import EllipsisType
-elif TYPE_CHECKING:
-    from typing_extensions import EllipsisType
-else:
-    EllipsisType = type(Ellipsis)
 
 
 class Device:

--- a/array_api_strict/_data_type_functions.py
+++ b/array_api_strict/_data_type_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 import numpy as np

--- a/array_api_strict/_dtypes.py
+++ b/array_api_strict/_dtypes.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import builtins
 import warnings
 from typing import Any, Final

--- a/array_api_strict/_elementwise_functions.py
+++ b/array_api_strict/_elementwise_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 
 from ._array_object import Array

--- a/array_api_strict/_fft.py
+++ b/array_api_strict/_fft.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 from typing import Literal
 

--- a/array_api_strict/_flags.py
+++ b/array_api_strict/_flags.py
@@ -11,24 +11,16 @@ None of these functions are part of the standard itself. A typical array API
 library will only support one particular configuration of these flags.
 
 """
-
-from __future__ import annotations
-
 import functools
 import os
 import warnings
 from collections.abc import Callable
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Collection, TypeVar, cast
+from typing import Any, Collection, ParamSpec, TypeVar, cast
 
 import array_api_strict
 
-if TYPE_CHECKING:
-    # TODO import from typing (requires Python >= 3.10)
-    from typing_extensions import ParamSpec
-
-    P = ParamSpec("P")
-
+P = ParamSpec("P")
 T = TypeVar("T")
 _CallableT = TypeVar("_CallableT", bound=Callable[..., object])
 

--- a/array_api_strict/_helpers.py
+++ b/array_api_strict/_helpers.py
@@ -1,7 +1,5 @@
 """Private helper routines."""
 
-from __future__ import annotations
-
 from ._array_object import Array
 from ._dtypes import _dtype_categories
 from ._flags import get_array_api_strict_flags

--- a/array_api_strict/_indexing_functions.py
+++ b/array_api_strict/_indexing_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 
 from ._array_object import Array

--- a/array_api_strict/_info.py
+++ b/array_api_strict/_info.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 
 from . import _dtypes as dt

--- a/array_api_strict/_linalg.py
+++ b/array_api_strict/_linalg.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 from functools import partial
 from typing import Literal, NamedTuple

--- a/array_api_strict/_linear_algebra_functions.py
+++ b/array_api_strict/_linear_algebra_functions.py
@@ -4,9 +4,6 @@ them here with wrappers in linalg so that the wrappers can be disabled if the
 linalg extension is disabled in the flags.
 
 """
-
-from __future__ import annotations
-
 from collections.abc import Sequence
 
 import numpy as np

--- a/array_api_strict/_manipulation_functions.py
+++ b/array_api_strict/_manipulation_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 
 from ._array_object import Array

--- a/array_api_strict/_searching_functions.py
+++ b/array_api_strict/_searching_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Literal
 
 import numpy as np

--- a/array_api_strict/_set_functions.py
+++ b/array_api_strict/_set_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import NamedTuple
 
 import numpy as np

--- a/array_api_strict/_sorting_functions.py
+++ b/array_api_strict/_sorting_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Literal
 
 import numpy as np

--- a/array_api_strict/_statistical_functions.py
+++ b/array_api_strict/_statistical_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import numpy as np

--- a/array_api_strict/_utility_functions.py
+++ b/array_api_strict/_utility_functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "array_api_strict"
 dynamic = ["version"]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = ["numpy"]
 license = {file = "LICENSE"}
 authors = [
@@ -15,7 +15,6 @@ description = "A strict, minimal implementation of the Python array API standard
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-[project-urls]
+[project.urls]
 Homepage = "https://data-apis.org/array-api-strict/"
 Repository = "https://github.com/data-apis/array-api-strict"
 


### PR DESCRIPTION
Follow-up to https://github.com/data-apis/array-api-strict/pull/129

CC @ev-br