### PR TITLE
MAINT: finfo() / iinfo() input/output review

### DIFF
--- a/array_api_strict/_dtypes.py
+++ b/array_api_strict/_dtypes.py
@@ -35,7 +35,7 @@ Such cross-library comparison is not supported by the standard.""",
                 stacklevel=2,
             )
         if not isinstance(other, DType):
-            return NotImplemented
+            return False
         return self._np_dtype == other._np_dtype
 
     def __hash__(self) -> int:


### PR DESCRIPTION
- Follow-up to bugfix to .dtype attribute in #135
- Closes #138
- Closes #116
- Make finfo/iinfo output uncomparable and unwriteable