### PR TITLE
Fix test_iter with Python 3.14 beta 1

### DIFF
--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -637,7 +637,7 @@ def test_array_namespace():
     pytest.raises(ValueError, lambda: a.__array_namespace__(api_version="2026.12"))
 
 def test_iter():
-    pytest.raises(TypeError, lambda: iter(asarray(3)))
+    pytest.raises(TypeError, lambda: next(iter(asarray(3))))
     assert list(ones(3)) == [asarray(1.), asarray(1.), asarray(1.)]
     assert all_(isinstance(a, Array) for a in iter(ones(3)))
     assert all_(a.shape == () for a in iter(ones(3)))


### PR DESCRIPTION
In Python 3.14 beta 1, generator expression returned by the __iter__ method needs to be executed to throw the expected TypeError.

Fixes: https://github.com/data-apis/array-api-strict/issues/151