### PR TITLE
Reinstate `__array__` on Python 3.10/3.11

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -11,12 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12', '3.13']
-        numpy-version: ['1.26', '2.2', 'dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        numpy-version: ['1.26', '2.3', 'dev']
         exclude:
+          - python-version: '3.10'
+            numpy-version: '2.3'
+          - python-version: '3.10'
+            numpy-version: 'dev'            
           - python-version: '3.13'
             numpy-version: '1.26'
-
+      fail-fast: false
     steps:
     - name: Checkout array-api-strict
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,11 +6,15 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        numpy-version: ['1.26', 'dev']
+        numpy-version: ['1.26', '2.3', 'dev']
         exclude:
+          - python-version: '3.10'
+            numpy-version: '2.3'
+          - python-version: '3.10'
+            numpy-version: 'dev'            
           - python-version: '3.13'
             numpy-version: '1.26'
-      fail-fast: true
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 2.4.1 (unreleased)
+
+### Major Changes
+
+- The array object defines `__array__` again when `__buffer__` is not available.
+
+- Support for Python versions 3.10 and 3.11 has been reinstated.
+
+
+### Minor Changes
+
+- Arithmetic operations no longer accept NumPy arrays.
+
+- Disallow `__setitem__` for invalid dtype combinations (e.g. setting a float value
+into an integer array)
+
+
+### Contributors
+
+The following users contributed to this release:
+
+Evgeni Burovski,
+Guido Imperiale
+
+
 ## 2.4.0 (2025-06-16)
 
 ### Major Changes


### PR DESCRIPTION
- Towards #160 (need to release 2.4.1, wait some time, and yank 2.4 to close it)
- Reinstate support for Python 3.10 and 3.11
- Bump NumPy in CI from 2.2 to 2.3