### PR TITLE
BUG: make clip(x) return a copy

### DIFF
--- a/array_api_strict/_elementwise_functions.py
+++ b/array_api_strict/_elementwise_functions.py
@@ -257,7 +257,7 @@ def clip(
         raise TypeError("Only real numeric dtypes are allowed in clip")
 
     if min is max is None:
-        return x
+        return Array._new(x._array.copy(), device=x.device)
 
     for argname, arg in ("min", min), ("max", max):
         if isinstance(arg, Array):

--- a/array_api_strict/tests/test_elementwise_functions.py
+++ b/array_api_strict/tests/test_elementwise_functions.py
@@ -312,3 +312,12 @@ def test_scalars():
 
                         with pytest.raises(TypeError):
                             func(s, s)
+
+
+def test_clip_none():
+    # regression test: clip(x) is a copy of x, not a view
+    x = asarray([1, 2, 3])
+    y = array_api_strict.clip(x)
+
+    y[1] = 42
+    assert x[1] == 2


### PR DESCRIPTION
Make it follow numpy 2.x, and all array-api-compat wrapped namespaces.

cross-ref https://github.com/data-apis/array-api-compat/pull/382 for a test of wrapped namespaces.

Reference behavior:

```
In [1]: import numpy as np

In [2]: np.__version__
Out[2]: '2.3.5'

In [3]: x = np.arange(8)

In [4]: y = np.clip(x)

In [5]: y[1] = 42

In [6]: y
Out[6]: array([ 0, 42,  2,  3,  4,  5,  6,  7])

In [7]: x
Out[7]: array([0, 1, 2, 3, 4, 5, 6, 7])

```