### PR TITLE
BUG: clip: allow clip(float_array, min=int_scalar)

### DIFF
--- a/array_api_strict/_elementwise_functions.py
+++ b/array_api_strict/_elementwise_functions.py
@@ -278,8 +278,8 @@ def clip(
                 isinstance(arg, Array) and arg.dtype in _real_floating_dtypes)):
             raise TypeError(f"{argname} must be integral when x is integral")
         if (x.dtype in _real_floating_dtypes
-            and (isinstance(arg, int) or
-                isinstance(arg, Array) and arg.dtype in _integer_dtypes)):
+            and (isinstance(arg, Array) and arg.dtype in _integer_dtypes)
+        ):
             raise TypeError(f"{arg} must be floating-point when x is floating-point")
 
     # Normalize to make the below logic simpler


### PR DESCRIPTION
Python integers can be promoted together with float arrays.

a matching test is https://github.com/data-apis/array-api-tests/pull/411