### PR TITLE
API: expand_dims axis argument kwd or positional

### DIFF
--- a/array_api_strict/_manipulation_functions.py
+++ b/array_api_strict/_manipulation_functions.py
@@ -30,7 +30,7 @@ def concat(
     )
 
 
-def expand_dims(x: Array, /, *, axis: int) -> Array:
+def expand_dims(x: Array, /, axis: int) -> Array:
     """
     Array API compatible wrapper for :py:func:`np.expand_dims <numpy.expand_dims>`.
 


### PR DESCRIPTION
In the spec, `expand_dims` accepts axis as either keyword or positional argument, cf
https://data-apis.org/array-api/2024.12/API_specification/generated/array_api.expand_dims.html#array_api.expand_dims