### PR TITLE
CI: test latest releasted numpy; drop py 3.11,3.12

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        numpy-version: ['1.26', '2.3.5', 'dev']
+        python-version: ['3.10', '3.13', '3.14']
+        numpy-version: ['1.26', 'latest', 'dev']
         exclude:
           - python-version: '3.10'
-            numpy-version: '2.3.5'
+            numpy-version: 'latest'
           - python-version: '3.10'
             numpy-version: 'dev'            
           - python-version: '3.13'
@@ -43,6 +43,8 @@ jobs:
         python -m pip install --upgrade pip
         if [[ "${{ matrix.numpy-version }}" == "dev" ]]; then
           python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy;
+        elif [[ "${{ matrix.numpy-version }}" == "latest" ]]; then
+          python -m pip install numpy
         else
           python -m pip install 'numpy=='${{ matrix.numpy-version }};
         fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        numpy-version: ['1.26', '2.3.5', 'dev']
+        python-version: ['3.10', '3.13', '3.14']
+        numpy-version: ['1.26', 'latest', 'dev']
         exclude:
           - python-version: '3.10'
-            numpy-version: '2.3.5'
+            numpy-version: 'latest'
           - python-version: '3.10'
             numpy-version: 'dev'            
           - python-version: '3.13'
@@ -27,6 +27,8 @@ jobs:
           python -m pip install --upgrade pip
           if [[ "${{ matrix.numpy-version }}" == "dev" ]]; then
             python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy;
+          elif [[ "${{ matrix.numpy-version }}" == "latest" ]]; then
+            python -m pip install numpy
           else
             python -m pip install 'numpy=='${{ matrix.numpy-version }}
           fi


### PR DESCRIPTION
Stop hardcoding numpy 2.3.5 as the latest version. While at it, drop python 3.11 and 3.12, only keep 3.10 as the lowest supported version and 3.13,3.14.