### PR TITLE
Upper cap setuptools_scm to <10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0,<=75", "setuptools_scm>8"]
+requires = ["setuptools >= 61.0,<=75", "setuptools_scm>8,<10"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
CI started failing on March 27, 2026; setuptools_scm had several 10.0.x releases on March 25-March27.
cross-ref gh-197, gh-199