### PR TITLE
CI: add dependabot cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7     # optional
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Add a 7-day cooldown period for Dependabot updates.
similar to https://github.com/data-apis/array-api-compat/pull/422/