### PR TITLE
Add DLPack device number to arrays

### DIFF
--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -69,6 +69,35 @@ CPU_DEVICE = Device()
 ALL_DEVICES = (CPU_DEVICE, Device("device1"), Device("device2"))
 
 
+class DLDeviceType(IntEnum):
+    kDLCPU = 1
+    kDLCUDA = 2
+
+
+_DLPACK_DEVICE_FOR: Final[dict[Device, tuple[DLDeviceType, int]]] = {
+    CPU_DEVICE: (DLDeviceType.kDLCPU, 0),
+    Device("device1"): (DLDeviceType.kDLCUDA, 0),
+    Device("device2"): (DLDeviceType.kDLCUDA, 1),
+}
+
+_DLPACK_DEVICE_TO_LOGICAL: Final[dict[tuple[int, int], Device]] = {
+    (int(device_type), device_id): logical_device
+    for logical_device, (device_type, device_id) in _DLPACK_DEVICE_FOR.items()
+}
+
+
+def _normalize_dl_device(device_type: IntEnum | int, device_id: int) -> tuple[int, int]:
+    return (int(device_type), device_id)
+
+
+def _device_from_dlpack_device(
+    device_type: IntEnum | int, device_id: int
+) -> Device:
+    return _DLPACK_DEVICE_TO_LOGICAL.get(
+        _normalize_dl_device(device_type, device_id), CPU_DEVICE
+    )
+
+
 class Array:
     """
     n-d array object for the array API namespace.
@@ -630,22 +659,40 @@ class Array:
                 raise NotImplementedError("The copy argument to __dlpack__ is not yet implemented")
 
             return self._array.__dlpack__(stream=stream)
-        else:
-            kwargs = {'stream': stream}
-            if max_version is not _undef:
-                kwargs['max_version'] = max_version
-            if dl_device is not _undef:
-                kwargs['dl_device'] = dl_device
-            if copy is not _undef:
-                kwargs['copy'] = copy
-            return self._array.__dlpack__(**kwargs)
+
+        kwargs: dict[str, Any] = {'stream': stream}
+        self_dl_device = _normalize_dl_device(*_DLPACK_DEVICE_FOR[self._device])
+        cpu_dl_device = _normalize_dl_device(DLDeviceType.kDLCPU, 0)
+        numpy_dl_device: tuple[IntEnum, int] | None = None
+
+        if dl_device not in [_undef, None]:
+            requested = _normalize_dl_device(dl_device[0], dl_device[1])
+            if requested == self_dl_device:
+                pass
+            elif requested == cpu_dl_device and self_dl_device != cpu_dl_device:
+                if copy is False:
+                    raise BufferError(
+                        "Cannot export array to CPU without copying when copy=False"
+                    )
+                if copy is _undef:
+                    copy = True
+                numpy_dl_device = (DLDeviceType.kDLCPU, 0)
+            else:
+                raise BufferError("unsupported device requested")
+
+        if max_version is not _undef:
+            kwargs['max_version'] = max_version
+        if numpy_dl_device is not None:
+            kwargs['dl_device'] = numpy_dl_device
+        if copy is not _undef:
+            kwargs['copy'] = copy
+        return self._array.__dlpack__(**kwargs)
 
     def __dlpack_device__(self) -> tuple[IntEnum, int]:
         """
         Performs the operation __dlpack_device__.
         """
-        # Note: device support is required for this
-        return self._array.__dlpack_device__()
+        return _DLPACK_DEVICE_FOR[self._device]
 
     def __eq__(self, other: Array | complex, /) -> Array:  # type: ignore[override]
         """

--- a/array_api_strict/_creation_functions.py
+++ b/array_api_strict/_creation_functions.py
@@ -216,6 +216,11 @@ def from_dlpack(
         _check_device(device)
     else:
         device = None
+        if hasattr(x, "__dlpack_device__"):
+            from ._array_object import _device_from_dlpack_device
+
+            dl_type, dl_id = x.__dlpack_device__()
+            device = _device_from_dlpack_device(dl_type, dl_id)
     if copy in [_undef, None]:
         # numpy 1.26 does not have the copy= arg
         return Array._new(np.from_dlpack(x), device=device)

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from .. import ones, arange, reshape, asarray, result_type, all, equal, stack
-from .._array_object import Array, CPU_DEVICE, Device
+from .._array_object import Array, CPU_DEVICE, Device, DLDeviceType
 from .._dtypes import (
     _all_dtypes,
     _boolean_dtypes,
@@ -748,6 +748,40 @@ def test_dlpack_2023_12(api_version):
         a.__dlpack__(copy=False)
         a.__dlpack__(copy=True)
         a.__dlpack__(copy=None)
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [
+        (CPU_DEVICE, (DLDeviceType.kDLCPU, 0)),
+        (Device("device1"), (DLDeviceType.kDLCUDA, 0)),
+        (Device("device2"), (DLDeviceType.kDLCUDA, 1)),
+    ],
+)
+def test_dlpack_device_numbers(device, expected):
+    a = asarray([1, 2, 3], device=device)
+    assert a.__dlpack_device__() == expected
+
+
+@pytest.mark.parametrize("device", [CPU_DEVICE, Device("device1"), Device("device2")])
+def test_dlpack_export_with_matching_dl_device(device):
+    if np.lib.NumpyVersion(np.__version__) < "2.1.0":
+        pytest.skip("dl_device argument requires NumPy >= 2.1.0")
+    set_array_api_strict_flags(api_version="2023.12")
+
+    a = asarray([1, 2, 3], device=device)
+    a.__dlpack__(dl_device=a.__dlpack_device__())
+
+
+@pytest.mark.parametrize("device", [Device("device1"), Device("device2")])
+def test_dlpack_cross_device_export_buffer_error(device):
+    if np.lib.NumpyVersion(np.__version__) < "2.1.0":
+        pytest.skip("dl_device argument requires NumPy >= 2.1.0")
+    set_array_api_strict_flags(api_version="2023.12")
+
+    a = asarray([1, 2, 3], device=device)
+    with pytest.raises(BufferError):
+        a.__dlpack__(dl_device=(DLDeviceType.kDLCPU, 0), copy=False)
+
 
 def test_pickle():
     """Check that arrays are pickleable (despite raising on `__new__`)"""

--- a/array_api_strict/tests/test_creation_functions.py
+++ b/array_api_strict/tests/test_creation_functions.py
@@ -247,3 +247,13 @@ def test_from_dlpack_default_device():
     y = from_dlpack(x)
     z = from_dlpack(np.asarray([1, 2, 3]))
     assert x.device == y.device == z.device == CPU_DEVICE
+
+
+@pytest.mark.parametrize(
+    "device",
+    [Device("device1"), Device("device2")],
+)
+def test_from_dlpack_preserves_device(device):
+    x = asarray([1, 2, 3], device=device)
+    y = from_dlpack(x)
+    assert y.device == device


### PR DESCRIPTION
While doing some work on scikit-learn I discovered that the device type ID for arrays that are not using the default device are still equal to the CPU device type ID. The reason I noticed is that I was exploring using the DLPack device type ID as a way to tell if something was on the CPU or "some other device" in a array namespace neutral way. Being able to use array-api-strict to test code and pretend to be on a "GPU" is useful because you can run those tests without actually having a "not CPU" device.

I think it makes sense to make the device type ID consistent with how the additional devices in array-api-strict work. They are meant to be devices from which you can't `np.asarray(my_array)` and simulate a "GPU" device that has its own memory, etc.

The result is this PR. This is how things look when you use it:
```python
import array_api_strict as xp
from array_api_strict import from_dlpack

# Each logical device maps to a distinct DLPack (device_type, device_id)
for name in ("CPU_DEVICE", "device1", "device2"):
    device = xp.Device(name) if name != "CPU_DEVICE" else xp.CPU_DEVICE
    a = xp.asarray([1, 2, 3], device=device)
    print(f"{name:12} -> {a.__dlpack_device__()}")
# CPU_DEVICE   -> (<DLDeviceType.kDLCPU: 1>, 0)
# device1      -> (<DLDeviceType.kDLCUDA: 2>, 0)
# device2      -> (<DLDeviceType.kDLCUDA: 2>, 1)

# from_dlpack preserves the logical device when device=None
a = xp.asarray([1, 2, 3], device=xp.Device("device1"))
b = from_dlpack(a)
assert b.device == a.device
assert b.__dlpack_device__() == (2, 0)  # kDLCUDA, device 0
```


I am not particularly attached to the actual implementation. It is the result of asking AI to make a sketch of how this would look and feel. I've not tried to find things that break as a result of this change beyond writing new tests and running the test suite. You could argue that this should be an issue instead of a PR, but I had the code so I thought I'd put it up so people can look at it.

What do y'all think about the idea of changing the device type ID for arrays that use one of the non-default devices?

Kinda related to #70