### PR TITLE
WIP: add a basic `top_k` implementation

### DIFF
--- a/array_api_strict/__init__.py
+++ b/array_api_strict/__init__.py
@@ -303,10 +303,11 @@ from ._searching_functions import (
     count_nonzero,
     nonzero,
     searchsorted,
+    top_k,
     where,
 )
 
-__all__ += ["argmax", "argmin", "count_nonzero", "nonzero", "searchsorted", "where"]
+__all__ += ["argmax", "argmin", "count_nonzero", "nonzero", "searchsorted", "top_k", "where"]
 
 from ._set_functions import (
     isin,

--- a/array_api_strict/_searching_functions.py
+++ b/array_api_strict/_searching_functions.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, NamedTuple
 
 import numpy as np
 
@@ -10,6 +10,11 @@ from ._flags import (
     requires_data_dependent_shapes,
 )
 from ._helpers import _maybe_normalize_py_scalars
+
+
+class TopKResult(NamedTuple):
+    values: Array
+    indices: Array
 
 
 def argmax(x: Array, /, *, axis: int | None = None, keepdims: bool = False) -> Array:
@@ -125,23 +130,46 @@ def where(condition: Array, x1: Array | complex, x2: Array | complex, /) -> Arra
     return Array._new(np.where(condition._array, x1._array, x2._array), device=x1.device)
 
 
-def top_k(a, k, /, axis=-1, *, mode="largest"):
+
+def top_k(
+    a: Array,
+    k: int,
+    /,
+    *,
+    axis: int =-1,
+    mode: Literal["largest", "smallest"] = "largest"
+) -> TopKResult:
+    """
+    Array API compatible wrapper for :py:func:`np.top_k <numpy.top_k>`.
+
+    See its docstring for more information.
+    """
     if k <= 0:
         raise ValueError(f'k(={k}) provided must be positive.')
 
-    positive_axis = axis if axis > 0 else axis % arr.ndim
+    if mode not in ["largest", "smallest"]:
+        raise ValueError(f'{mode = } not in ["largest", "smallest"]')
+
+    if k > a.shape[axis]:
+        raise ValueError(f"{k = } exceeds {a.shape[axis] = }") 
+
+    positive_axis = axis if axis > 0 else axis % a.ndim
+
+    arr = a._array
 
     slice_start = (np.s_[:],) * positive_axis
-    if largest:
+    if mode == "largest":
         indices_array = np.argpartition(arr, -k, axis=axis)
-        slice = slice_start + (np.s_[-k:],)
-        topk_indices = indices_array[slice]
+        slice_ = slice_start + (np.s_[-k:],)
+        topk_indices = indices_array[slice_]
     else:
         indices_array = np.argpartition(arr, k-1, axis=axis)
-        slice = slice_start + (np.s_[:k],)
-        topk_indices = indices_array[slice]
+        slice_ = slice_start + (np.s_[:k],)
+        topk_indices = indices_array[slice_]
 
     topk_values = np.take_along_axis(arr, topk_indices, axis=axis)
 
-    return topk_values, topk_indices
-
+    return TopKResult(
+        Array._new(topk_values, device=a.device),
+        Array._new(topk_indices, device=a.device)
+    )

--- a/array_api_strict/_searching_functions.py
+++ b/array_api_strict/_searching_functions.py
@@ -123,3 +123,25 @@ def where(condition: Array, x1: Array | complex, x2: Array | complex, /) -> Arra
 
     x1, x2 = Array._normalize_two_args(x1, x2)
     return Array._new(np.where(condition._array, x1._array, x2._array), device=x1.device)
+
+
+def top_k(a, k, /, axis=-1, *, mode="largest"):
+    if k <= 0:
+        raise ValueError(f'k(={k}) provided must be positive.')
+
+    positive_axis = axis if axis > 0 else axis % arr.ndim
+
+    slice_start = (np.s_[:],) * positive_axis
+    if largest:
+        indices_array = np.argpartition(arr, -k, axis=axis)
+        slice = slice_start + (np.s_[-k:],)
+        topk_indices = indices_array[slice]
+    else:
+        indices_array = np.argpartition(arr, k-1, axis=axis)
+        slice = slice_start + (np.s_[:k],)
+        topk_indices = indices_array[slice]
+
+    topk_values = np.take_along_axis(arr, topk_indices, axis=axis)
+
+    return topk_values, topk_indices
+


### PR DESCRIPTION
Per https://github.com/data-apis/array-api/pull/722/

This is based on `argsort`, so should work for older, released numpies. The implementation is based on https://github.com/data-apis/array-api-compat/pull/158, updated to match the spec of https://github.com/data-apis/array-api/pull/722/

A matching tests PR is https://github.com/data-apis/array-api-tests/pull/438