### PR TITLE
BUG: disallow `None` in `__setitem__`

### DIFF
--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -429,7 +429,7 @@ class Array:
                 isinstance(i, SupportsIndex)  # i.e. ints
                 or isinstance(i, slice)
                 or i == Ellipsis
-                or i is None
+                or (op == "getitem" and i is None) # `None` disallowed in setitem
                 or isinstance(i, Array)
                 or isinstance(i, np.ndarray)
             ):


### PR DESCRIPTION
Closes https://github.com/data-apis/array-api-extra/issues/822. Found while performing typing work on SciPy at https://github.com/scipy/scipy/pull/25517.