### PR TITLE
ENH: add a `no x64` device

### DIFF
--- a/array_api_strict/_devices.py
+++ b/array_api_strict/_devices.py
@@ -2,13 +2,13 @@ from typing import Final
 from enum import IntEnum
 
 from ._dtypes import (
-    DType, float32, float64, complex64, complex128, int64,
+    DType, float32, float64, complex64, complex128, int64, uint64, int32,
     _all_dtypes, _boolean_dtypes, _signed_integer_dtypes,
     _unsigned_integer_dtypes, _integer_dtypes, _real_floating_dtypes,
     _complex_floating_dtypes, _numeric_dtypes
 )
 
-_ALL_DEVICE_NAMES = ("CPU_DEVICE", "device1", "device2", "no_float64")
+_ALL_DEVICE_NAMES = ("CPU_DEVICE", "device1", "device2", "no_float64", "no_x64")
 
 class Device:
     _device: Final[str]
@@ -33,8 +33,11 @@ class Device:
 
 CPU_DEVICE = Device()
 NO_FLOAT64_DEVICE = Device("no_float64")
+NO_X64_DEVICE = Device("no_x64")
 
-ALL_DEVICES = (CPU_DEVICE, Device("device1"), Device("device2"), NO_FLOAT64_DEVICE)
+ALL_DEVICES = (
+    CPU_DEVICE, Device("device1"), Device("device2"), NO_FLOAT64_DEVICE, NO_X64_DEVICE
+)
 
 class DLDeviceType(IntEnum):
     kDLCPU = 1
@@ -85,6 +88,14 @@ def get_default_dtypes(device: Device | None = None) -> dict[str, DType]:
             "integral": int64,
             "indexing": int64,
         }
+    elif device == NO_X64_DEVICE:
+        # mimic JAX default: no float64, no int64
+        return {
+            "real floating": float32,
+            "complex floating": complex64,
+            "integral": int32,
+            "indexing": int32,
+        }
     elif device == Device('device2'):
         # mimic a torch CPU device: support float64 but default to float32
         return {
@@ -107,6 +118,9 @@ def device_supports_dtype(device: Device | None, dtype: DType |None) -> bool:
     # Device("no_float64") supports all dtypes except float64 and complex128
     if device == NO_FLOAT64_DEVICE:
         return dtype not in (float64, complex128)
+    if device == NO_X64_DEVICE:
+        # "no_x64" only supports 32-bit ints and floats
+        return dtype not in (float64, complex128, int64, uint64)
 
     # All other devices support all dtypes
     return True

--- a/array_api_strict/tests/test_creation_functions.py
+++ b/array_api_strict/tests/test_creation_functions.py
@@ -22,7 +22,7 @@ from .._creation_functions import (
     zeros,
     zeros_like,
 )
-from .._dtypes import float32, float64, complex64, bool as xp_bool
+from .._dtypes import float32, float64, complex64, int32, int64, bool as xp_bool
 from .._array_object import Array
 from .._devices import CPU_DEVICE, ALL_DEVICES, Device
 from .._info import __array_namespace_info__
@@ -373,6 +373,17 @@ def test_asarray_device_1():
     x = np.ones(3, dtype=np.float32)
     y = asarray(x, device=Device('device1'))
     assert y.dtype == float32
+
+
+def test_asarray_no_x64_device():
+    x = asarray(3, device=Device("no_x64"))
+    assert x.dtype == int32
+
+    with pytest.raises(ValueError):
+        asarray(3, device=Device("no_x64"), dtype=int64)
+
+    y = zeros_like(ones(3, dtype=int32), device=Device("no_x64"))
+    assert y.dtype == int32
 
 
 @pytest.mark.parametrize("api_version", ['2021.12', '2022.12', '2023.12'])


### PR DESCRIPTION
Add a "no_x64" device which only supports 32-bit ints and floats.

This device mimics the JAX's default (and the name follows the  JAX `jax_enable_x64` flag name). 
As discussed and requested in the Array API meeting on Jul 09.

For convenience, this PR is on top of gh-221, so only the last commit, c180b0e2cec28dcb7253dd9d0de0a290c14ac06b,  is relevant.
Since we're getting a 2.6.1 release "quickly", and a `no_float64` device was added in 2.6, I'm thinking about sneaking this new device into 2.6.1, too. Thoughts?