### PR TITLE
CI: pin ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install "ruff<0.16"
       # Update output format to enable automatic inline annotations.
       - name: Run Ruff
         run: ruff check --output-format=github .


### PR DESCRIPTION
ruff==0.16.0 (released Jul 23, 2026) emits a new wall of warnings, pin it to a previous version for the time being.

From the release notes (https://astral.sh/blog/ruff-v0.16.0):

> Better default rule set
> Ruff now enables 413 rules by default, up from 59 in previous versions.
