### PR TITLE
BUG: `reshape` accept an empty array and copy=False

### DIFF
--- a/array_api_strict/_manipulation_functions.py
+++ b/array_api_strict/_manipulation_functions.py
@@ -122,8 +122,8 @@ def reshape(x: Array, /, shape: tuple[int, ...], *, copy: bool | None = None) ->
 
     reshaped = np.reshape(data, shape)
 
-    if copy is False and not np.shares_memory(data, reshaped):
-        raise AttributeError("Incompatible shape for in-place modification.")
+    if copy is False and data.size > 0 and not np.shares_memory(data, reshaped):
+        raise ValueError("Incompatible shape for a no-copy reshape.")
 
     return Array._new(reshaped, device=x.device)
 

--- a/array_api_strict/_manipulation_functions.py
+++ b/array_api_strict/_manipulation_functions.py
@@ -122,6 +122,7 @@ def reshape(x: Array, /, shape: tuple[int, ...], *, copy: bool | None = None) ->
 
     reshaped = np.reshape(data, shape)
 
+    # NB: `.size>0` works around that `x=np.asarray([]); np.shares_memory(x, x)` is False
     if copy is False and data.size > 0 and not np.shares_memory(data, reshaped):
         raise ValueError("Incompatible shape for a no-copy reshape.")
 

--- a/array_api_strict/tests/test_manipulation_functions.py
+++ b/array_api_strict/tests/test_manipulation_functions.py
@@ -32,5 +32,15 @@ def test_reshape_copy():
 
     a = asarray(np.ones((2, 3)).T)
     b = reshape(a, (3, 2), copy=True)
-    assert_raises(AttributeError, lambda: reshape(a, (2, 3), copy=False))
+    assert_raises(ValueError, lambda: reshape(a, (2, 3), copy=False))
+
+
+def test_reshape_copy_false_keeps_an_empty_view():
+    a = asarray(np.empty((0,)))
+    b = reshape(a, (0, 2), copy=False)
+    assert b.shape == (0, 2)
+
+    a = asarray(np.empty((0, 2)))
+    b = reshape(a, (2, 0), copy=False)
+    assert b.shape == (2, 0)
 


### PR DESCRIPTION
`reshape` with `copy=False` rejects an empty view.

Skip the `shares_memory` view test for an empty array, so `reshape` with `copy=False` returns the view.

Raise `ValueError` instead of `AttributeError` when a copy is necessary. The 2025.12 specification requires `ValueError` when `copy=False` needs a copy, and numpy raises the same type.

The failing `reshape` test in data-apis/array-api-tests#432 passes with this change.

All tests pass.
