### PR TITLE
Improve DLPack support for non CPU devices

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,16 @@ jobs:
           - python-version: '3.10'
             numpy-version: 'latest'
           - python-version: '3.10'
-            numpy-version: 'dev'            
+            numpy-version: 'dev'
           - python-version: '3.13'
             numpy-version: '1.26'
           - python-version: '3.14'
             numpy-version: '1.26'
+        include:
+          # exercise the DLPack interop tests, which need another array library
+          - python-version: '3.13'
+            numpy-version: 'latest'
+            torch: true
       fail-fast: false
     steps:
       - uses: actions/checkout@v7.0.1
@@ -34,6 +39,11 @@ jobs:
           fi
           python -m pip install pytest hypothesis
           python -c'import numpy as np; print(f"{np.__version__ = }")'
+      - name: Install PyTorch
+        if: matrix.torch
+        run: |
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -c'import torch; print(f"{torch.__version__ = }")'
       - name: Run Tests
         run: |
           pytest

--- a/array-api-tests-xfails.txt
+++ b/array-api-tests-xfails.txt
@@ -46,9 +46,5 @@ array_api_tests/test_special_cases.py::test_unary[acosh(real(x_i) is +0 and imag
 
 array_api_tests/test_special_cases.py::test_unary[sqrt(real(x_i) is +infinity and isfinite(imag(x_i)) and imag(x_i) > 0) -> +0 + infinity j]
 
-# remove this when array-api-strict 2.6 is released: this is only for array-api-tests,
-# which runs self-tests against a released array-api-strict
-array_api_tests/test_dlpack.py::test_from_dlpack
-
 # NumPy 1.26 : NotImplementedError: The copy argument to __dlpack__ is not yet implemented
 array_api_tests/test_dlpack.py::test_dunder_dlpack

--- a/array_api_strict/_array_object.py
+++ b/array_api_strict/_array_object.py
@@ -40,7 +40,13 @@ from ._dtypes import (
     _real_to_complex_map,
     _result_type,
 )
-from ._devices import CPU_DEVICE, Device, device_supports_dtype
+from ._devices import (
+    CPU_DEVICE,
+    Device,
+    _DLPACK_DEVICE_FOR,
+    _normalize_dl_device,
+    device_supports_dtype,
+)
 from ._flags import get_array_api_strict_flags, set_array_api_strict_flags
 from ._typing import PyCapsule
 
@@ -602,6 +608,15 @@ class Array:
             if copy is not _undef:
                 raise ValueError("The copy argument to __dlpack__ requires at least version 2023.12 of the array API")
 
+        if self._device != CPU_DEVICE:
+            # Consistent with __buffer__ and __array__: data cannot leave a
+            # non-CPU device implicitly. Note that this also rules out consumers
+            # asking for the CPU device via dl_device: the array has to be moved
+            # to the CPU device first, with to_device or asarray.
+            raise BufferError(
+                f"Can't export array on the '{self._device}' device via DLPack."
+            )
+
         if np.lib.NumpyVersion(np.__version__) < '2.1.0':
             if max_version not in [_undef, None]:
                 raise NotImplementedError("The max_version argument to __dlpack__ is not yet implemented")
@@ -611,12 +626,20 @@ class Array:
                 raise NotImplementedError("The copy argument to __dlpack__ is not yet implemented")
 
             return self._array.__dlpack__(stream=stream)
-        else:
-            kwargs = {'stream': stream}
-            if max_version is not _undef:
-                kwargs['max_version'] = max_version
-            if dl_device is not _undef:
-                kwargs['dl_device'] = dl_device
+
+        kwargs: dict[str, Any] = {'stream': stream}
+        if max_version is not _undef:
+            kwargs['max_version'] = max_version
+        if dl_device is not _undef:
+            if dl_device is not None:
+                requested = _normalize_dl_device(*dl_device)
+                if requested != _normalize_dl_device(*_DLPACK_DEVICE_FOR[self._device]):
+                    raise BufferError("unsupported device requested")
+                # The request is for the device the array is already on, which a
+                # plain export satisfies. NumPy is not told about it, as it only
+                # knows about its own spelling of the CPU device.
+                dl_device = None
+            kwargs['dl_device'] = dl_device
         if copy is not _undef:
             kwargs['copy'] = copy
         return self._array.__dlpack__(**kwargs)
@@ -625,8 +648,7 @@ class Array:
         """
         Performs the operation __dlpack_device__.
         """
-        # Note: device support is required for this
-        return self._array.__dlpack_device__()
+        return _DLPACK_DEVICE_FOR[self._device]
 
     def __eq__(self, other: Array | complex, /) -> Array:  # type: ignore[override]
         """

--- a/array_api_strict/_creation_functions.py
+++ b/array_api_strict/_creation_functions.py
@@ -250,7 +250,11 @@ def from_dlpack(
         _check_device(device)
     else:
         device = None
-        if hasattr(x, "__dlpack_device__"):
+        if isinstance(x, Array):
+            # All the devices of this library share a DLPack device, so the
+            # logical device is read off the array itself.
+            device = x.device
+        elif hasattr(x, "__dlpack_device__"):
             dl_type, dl_id = x.__dlpack_device__()
             device = _device_from_dlpack_device(dl_type, dl_id)
 

--- a/array_api_strict/_creation_functions.py
+++ b/array_api_strict/_creation_functions.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ._dtypes import DType, _all_dtypes, _np_dtype, bool as xp_bool
 from ._devices import (
-    Device, device_supports_dtype, get_default_dtypes,
+    Device, device_supports_dtype, get_default_dtypes, _device_from_dlpack_device,
     check_device as _check_device
 )
 from ._flags import get_array_api_strict_flags
@@ -250,6 +250,15 @@ def from_dlpack(
         _check_device(device)
     else:
         device = None
+        if hasattr(x, "__dlpack_device__"):
+            dl_type, dl_id = x.__dlpack_device__()
+            device = _device_from_dlpack_device(dl_type, dl_id)
+
+    if isinstance(x, Array):
+        # Arrays of this library are unwrapped instead of going through DLPack:
+        # the buffer is in host memory whatever the logical device is, and the
+        # DLPack export refuses arrays which are not on the CPU device.
+        x = x._array
 
     if copy in [_undef, None]:
         # numpy 1.26 does not have the copy= arg

--- a/array_api_strict/_creation_functions.py
+++ b/array_api_strict/_creation_functions.py
@@ -264,9 +264,14 @@ def from_dlpack(
         # DLPack export refuses arrays which are not on the CPU device.
         x = x._array
 
-    if copy in [_undef, None]:
-        # numpy 1.26 does not have the copy= arg
-        return Array._new(np.from_dlpack(x), device=device)
+    if copy is _undef:
+        copy = None
+
+    if np.lib.NumpyVersion(np.__version__) < '2.1.0':
+        # numpy 1.26 does not have the copy= arg, and its from_dlpack never
+        # copies: copy=False needs nothing extra, copy=True is done here.
+        out = np.from_dlpack(x)
+        return Array._new(np.copy(out) if copy else out, device=device)
 
     return Array._new(np.from_dlpack(x, copy=copy), device=device)
 

--- a/array_api_strict/_devices.py
+++ b/array_api_strict/_devices.py
@@ -60,21 +60,19 @@ class DLDeviceType(IntEnum):
 
 
 # All the devices of array_api_strict are fictitious and their data lives in host
-# memory, so they all report the CPU device type and are told apart by their device
-# id. Reporting anything else makes consumers such as pytorch dispatch to the
-# machinery of a device they cannot actually reach, see
+# memory, so they all report the CPU device, which is device number zero. Reporting
+# anything else makes consumers such as pytorch dispatch to the machinery of a
+# device they cannot actually reach, see
 # https://github.com/data-apis/array-api-strict/issues/219
+# The logical devices cannot be told apart through DLPack, which is fine: only the
+# CPU device can be exported at all, and from_dlpack recovers the logical device of
+# an array from this library without going through DLPack.
 _DLPACK_DEVICE_FOR: Final[dict[Device, tuple[DLDeviceType, int]]] = {
-    CPU_DEVICE: (DLDeviceType.kDLCPU, 0),
-    Device("device1"): (DLDeviceType.kDLCPU, 1),
-    Device("device2"): (DLDeviceType.kDLCPU, 2),
-    NO_FLOAT64_DEVICE: (DLDeviceType.kDLCPU, 3),
-    NO_X64_DEVICE: (DLDeviceType.kDLCPU, 4),
+    device: (DLDeviceType.kDLCPU, 0) for device in ALL_DEVICES
 }
 
 _DLPACK_DEVICE_TO_LOGICAL: Final[dict[tuple[int, int], Device]] = {
-    (int(device_type), device_id): logical_device
-    for logical_device, (device_type, device_id) in _DLPACK_DEVICE_FOR.items()
+    (int(DLDeviceType.kDLCPU), 0): CPU_DEVICE,
 }
 
 

--- a/array_api_strict/_devices.py
+++ b/array_api_strict/_devices.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 from typing import Final
 
 from ._dtypes import (
@@ -37,6 +38,66 @@ NO_X64_DEVICE = Device("no_x64")
 ALL_DEVICES = (
     CPU_DEVICE, Device("device1"), Device("device2"), NO_FLOAT64_DEVICE, NO_X64_DEVICE
 )
+
+
+class DLDeviceType(IntEnum):
+    """The DLPack device types, as defined by the DLPack ABI."""
+    kDLCPU = 1
+    kDLCUDA = 2
+    kDLCUDAHost = 3
+    kDLOpenCL = 4
+    kDLVulkan = 7
+    kDLMetal = 8
+    kDLVPI = 9
+    kDLROCM = 10
+    kDLROCMHost = 11
+    kDLExtDev = 12
+    kDLCUDAManaged = 13
+    kDLOneAPI = 14
+    kDLWebGPU = 15
+    kDLHexagon = 16
+    kDLMAIA = 17
+
+
+# All the devices of array_api_strict are fictitious and their data lives in host
+# memory, so they all report the CPU device type and are told apart by their device
+# id. Reporting anything else makes consumers such as pytorch dispatch to the
+# machinery of a device they cannot actually reach, see
+# https://github.com/data-apis/array-api-strict/issues/219
+_DLPACK_DEVICE_FOR: Final[dict[Device, tuple[DLDeviceType, int]]] = {
+    CPU_DEVICE: (DLDeviceType.kDLCPU, 0),
+    Device("device1"): (DLDeviceType.kDLCPU, 1),
+    Device("device2"): (DLDeviceType.kDLCPU, 2),
+    NO_FLOAT64_DEVICE: (DLDeviceType.kDLCPU, 3),
+    NO_X64_DEVICE: (DLDeviceType.kDLCPU, 4),
+}
+
+_DLPACK_DEVICE_TO_LOGICAL: Final[dict[tuple[int, int], Device]] = {
+    (int(device_type), device_id): logical_device
+    for logical_device, (device_type, device_id) in _DLPACK_DEVICE_FOR.items()
+}
+
+
+def _normalize_dl_device(device_type: IntEnum | int, device_id: int) -> tuple[int, int]:
+    # `device_type` may be a member of another library's DLPack enum
+    return (int(device_type), device_id)
+
+
+def _device_from_dlpack_device(
+    device_type: IntEnum | int, device_id: int
+) -> Device:
+    key = _normalize_dl_device(device_type, device_id)
+    try:
+        return _DLPACK_DEVICE_TO_LOGICAL[key]
+    except KeyError:
+        try:
+            type_name = DLDeviceType(key[0]).name
+        except ValueError:
+            type_name = str(key[0])
+        raise BufferError(
+            f"No array_api_strict device matches the DLPack device "
+            f"({type_name}, {device_id})."
+        ) from None
 
 
 def check_device(device: Device | None) -> None:

--- a/array_api_strict/_devices.py
+++ b/array_api_strict/_devices.py
@@ -42,21 +42,16 @@ ALL_DEVICES = (
 
 class DLDeviceType(IntEnum):
     """The DLPack device types, as defined by the DLPack ABI."""
-    kDLCPU = 1
-    kDLCUDA = 2
-    kDLCUDAHost = 3
-    kDLOpenCL = 4
-    kDLVulkan = 7
-    kDLMetal = 8
-    kDLVPI = 9
-    kDLROCM = 10
-    kDLROCMHost = 11
-    kDLExtDev = 12
-    kDLCUDAManaged = 13
-    kDLOneAPI = 14
-    kDLWebGPU = 15
-    kDLHexagon = 16
-    kDLMAIA = 17
+    CPU = 1
+    CUDA = 2
+    CUDA_HOST = 3
+    OPENCL = 4
+    VULKAN = 7
+    METAL = 8
+    VPI = 9
+    ROCM = 10
+    CUDA_MANAGED = 13
+    ONE_API = 14
 
 
 # All the devices of array_api_strict are fictitious and their data lives in host
@@ -68,11 +63,11 @@ class DLDeviceType(IntEnum):
 # CPU device can be exported at all, and from_dlpack recovers the logical device of
 # an array from this library without going through DLPack.
 _DLPACK_DEVICE_FOR: Final[dict[Device, tuple[DLDeviceType, int]]] = {
-    device: (DLDeviceType.kDLCPU, 0) for device in ALL_DEVICES
+    device: (DLDeviceType.CPU, 0) for device in ALL_DEVICES
 }
 
 _DLPACK_DEVICE_TO_LOGICAL: Final[dict[tuple[int, int], Device]] = {
-    (int(DLDeviceType.kDLCPU), 0): CPU_DEVICE,
+    (int(DLDeviceType.CPU), 0): CPU_DEVICE,
 }
 
 

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -799,7 +799,10 @@ def test_dlpack_export_from_non_cpu_device(device):
     with pytest.raises(BufferError):
         np.from_dlpack(a, device="cpu")
 
-    np.from_dlpack(a.to_device(CPU_DEVICE))
+    # explicitly move the array to CPU_DEVICE before handing to to DLPack
+    a_np = np.from_dlpack(a.to_device(CPU_DEVICE))
+    assert (a_np == a._array).all()
+    assert a_np.dtype == a._array.dtype
 
 
 def test_dlpack_export_from_cpu_device():

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -799,7 +799,8 @@ def test_dlpack_export_from_non_cpu_device(device):
     with pytest.raises(BufferError):
         np.from_dlpack(a, device="cpu")
 
-    # explicitly move the array to CPU_DEVICE before handing to to DLPack
+    # explicitly move the array to CPU_DEVICE before handing it to
+    # Numpy via DLPack
     a_np = np.from_dlpack(a.to_device(CPU_DEVICE))
     assert (a_np == a._array).all()
     assert a_np.dtype == a._array.dtype

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -761,25 +761,16 @@ def test_dlpack_2023_12(api_version):
         a.__dlpack__(copy=None)
 
 
-@pytest.mark.parametrize(
-    ("device", "expected"),
-    [
-        (CPU_DEVICE, (DLDeviceType.kDLCPU, 0)),
-        (Device("device1"), (DLDeviceType.kDLCPU, 1)),
-        (Device("device2"), (DLDeviceType.kDLCPU, 2)),
-        (Device("no_float64"), (DLDeviceType.kDLCPU, 3)),
-        (Device("no_x64"), (DLDeviceType.kDLCPU, 4)),
-    ],
-)
-def test_dlpack_device_numbers(device, expected):
+@pytest.mark.parametrize("device", ALL_DEVICES)
+def test_dlpack_device_numbers(device):
     a = asarray([1, 2, 3], device=device)
-    assert a.__dlpack_device__() == expected
+    # the data of every logical device lives in host memory, so they all report
+    # the CPU device, which is device number zero
+    assert a.__dlpack_device__() == (DLDeviceType.kDLCPU, 0)
 
 
 def test_dlpack_device_map_is_complete():
     assert set(_DLPACK_DEVICE_FOR) == set(ALL_DEVICES)
-    # devices which share a DLPack device cannot be told apart by from_dlpack
-    assert len(set(_DLPACK_DEVICE_FOR.values())) == len(ALL_DEVICES)
 
 
 @pytest.mark.parametrize(
@@ -797,11 +788,10 @@ def test_dlpack_export_from_non_cpu_device(device):
         return
 
     # asking for a device explicitly does not help: the array has to be moved
-    # to the CPU device first. Even asking for the device the array is already
-    # on is refused, since the capsule can only ever be tagged with the CPU
-    # device and the consumer would end up with the data on the wrong device.
-    # array-api-strict's special devices all use the same DLPack device number,
-    # but are meant to represent devices like a GPU or other accelerator.
+    # to the CPU device first. Even asking for the CPU device, which is what
+    # __dlpack_device__ reports, is refused: these devices are meant to
+    # represent a GPU or other accelerator, so the consumer would end up with
+    # the data on a device the array is not logically on.
     with pytest.raises(BufferError):
         a.__dlpack__(dl_device=a.__dlpack_device__())
     with pytest.raises(BufferError):

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -766,7 +766,7 @@ def test_dlpack_device_numbers(device):
     a = asarray([1, 2, 3], device=device)
     # the data of every logical device lives in host memory, so they all report
     # the CPU device, which is device number zero
-    assert a.__dlpack_device__() == (DLDeviceType.kDLCPU, 0)
+    assert a.__dlpack_device__() == (DLDeviceType.CPU, 0)
 
 
 def test_dlpack_device_map_is_complete():
@@ -795,7 +795,7 @@ def test_dlpack_export_from_non_cpu_device(device):
     with pytest.raises(BufferError):
         a.__dlpack__(dl_device=a.__dlpack_device__())
     with pytest.raises(BufferError):
-        a.__dlpack__(dl_device=(DLDeviceType.kDLCPU, 0))
+        a.__dlpack__(dl_device=(DLDeviceType.CPU, 0))
     with pytest.raises(BufferError):
         np.from_dlpack(a, device="cpu")
 
@@ -813,7 +813,7 @@ def test_dlpack_export_from_cpu_device():
 
     a.__dlpack__(dl_device=a.__dlpack_device__())
     with pytest.raises(BufferError):
-        a.__dlpack__(dl_device=(DLDeviceType.kDLCUDA, 0))
+        a.__dlpack__(dl_device=(DLDeviceType.CUDA, 0))
 
 
 def test_pickle():

--- a/array_api_strict/tests/test_array_object.py
+++ b/array_api_strict/tests/test_array_object.py
@@ -10,7 +10,9 @@ import pytest
 
 from .. import ones, arange, reshape, asarray, result_type, all, equal, stack
 from .._array_object import Array
-from .._devices import CPU_DEVICE, Device
+from .._devices import (
+    ALL_DEVICES, CPU_DEVICE, Device, DLDeviceType, _DLPACK_DEVICE_FOR
+)
 from .._dtypes import (
     _all_dtypes,
     _boolean_dtypes,
@@ -757,6 +759,71 @@ def test_dlpack_2023_12(api_version):
         a.__dlpack__(copy=False)
         a.__dlpack__(copy=True)
         a.__dlpack__(copy=None)
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [
+        (CPU_DEVICE, (DLDeviceType.kDLCPU, 0)),
+        (Device("device1"), (DLDeviceType.kDLCPU, 1)),
+        (Device("device2"), (DLDeviceType.kDLCPU, 2)),
+        (Device("no_float64"), (DLDeviceType.kDLCPU, 3)),
+        (Device("no_x64"), (DLDeviceType.kDLCPU, 4)),
+    ],
+)
+def test_dlpack_device_numbers(device, expected):
+    a = asarray([1, 2, 3], device=device)
+    assert a.__dlpack_device__() == expected
+
+
+def test_dlpack_device_map_is_complete():
+    assert set(_DLPACK_DEVICE_FOR) == set(ALL_DEVICES)
+    # devices which share a DLPack device cannot be told apart by from_dlpack
+    assert len(set(_DLPACK_DEVICE_FOR.values())) == len(ALL_DEVICES)
+
+
+@pytest.mark.parametrize(
+    "device", [device for device in ALL_DEVICES if device != CPU_DEVICE]
+)
+def test_dlpack_export_from_non_cpu_device(device):
+    a = asarray([1, 2, 3], device=device)
+
+    with pytest.raises(BufferError):
+        a.__dlpack__()
+    with pytest.raises(BufferError):
+        np.from_dlpack(a)
+
+    if np.lib.NumpyVersion(np.__version__) < "2.1.0":
+        return
+
+    # asking for a device explicitly does not help: the array has to be moved
+    # to the CPU device first. Even asking for the device the array is already
+    # on is refused, since the capsule can only ever be tagged with the CPU
+    # device and the consumer would end up with the data on the wrong device.
+    # array-api-strict's special devices all use the same DLPack device number,
+    # but are meant to represent devices like a GPU or other accelerator.
+    with pytest.raises(BufferError):
+        a.__dlpack__(dl_device=a.__dlpack_device__())
+    with pytest.raises(BufferError):
+        a.__dlpack__(dl_device=(DLDeviceType.kDLCPU, 0))
+    with pytest.raises(BufferError):
+        np.from_dlpack(a, device="cpu")
+
+    np.from_dlpack(a.to_device(CPU_DEVICE))
+
+
+def test_dlpack_export_from_cpu_device():
+    a = asarray([1, 2, 3])
+
+    a.__dlpack__()
+    np.from_dlpack(a)
+
+    if np.lib.NumpyVersion(np.__version__) < "2.1.0":
+        return
+
+    a.__dlpack__(dl_device=a.__dlpack_device__())
+    with pytest.raises(BufferError):
+        a.__dlpack__(dl_device=(DLDeviceType.kDLCUDA, 0))
 
 
 def test_pickle():

--- a/array_api_strict/tests/test_creation_functions.py
+++ b/array_api_strict/tests/test_creation_functions.py
@@ -24,7 +24,7 @@ from .._creation_functions import (
 )
 from .._dtypes import float32, float64, complex64, int32, int64, bool as xp_bool
 from .._array_object import Array
-from .._devices import CPU_DEVICE, ALL_DEVICES, Device
+from .._devices import CPU_DEVICE, ALL_DEVICES, Device, DLDeviceType
 from .._info import __array_namespace_info__
 from .._flags import set_array_api_strict_flags
 
@@ -412,4 +412,30 @@ def test_from_dlpack_default_device():
     y = from_dlpack(x)
     z = from_dlpack(np.asarray([1, 2, 3]))
     assert x.device == y.device == z.device == CPU_DEVICE
+
+
+@pytest.mark.parametrize("device", ALL_DEVICES)
+def test_from_dlpack_preserves_device(device):
+    x = asarray([1, 2, 3], device=device)
+    y = from_dlpack(x)
+    assert y.device == device
+
+
+def test_from_dlpack_unknown_device():
+    class ForeignArray:
+        """An array on a device which array_api_strict knows nothing about."""
+        def __init__(self):
+            self._array = np.asarray([1, 2, 3])
+
+        def __dlpack_device__(self):
+            return (DLDeviceType.kDLCUDA, 0)
+
+        def __dlpack__(self, **kwargs):
+            return self._array.__dlpack__(**kwargs)
+
+    with pytest.raises(BufferError):
+        from_dlpack(ForeignArray())
+
+    # an explicit device is a request to transfer, so nothing has to be inferred
+    assert from_dlpack(ForeignArray(), device=CPU_DEVICE).device == CPU_DEVICE
 

--- a/array_api_strict/tests/test_creation_functions.py
+++ b/array_api_strict/tests/test_creation_functions.py
@@ -428,7 +428,7 @@ def test_from_dlpack_unknown_device():
             self._array = np.asarray([1, 2, 3])
 
         def __dlpack_device__(self):
-            return (DLDeviceType.kDLCUDA, 0)
+            return (DLDeviceType.CUDA, 0)
 
         def __dlpack__(self, **kwargs):
             return self._array.__dlpack__(**kwargs)

--- a/array_api_strict/tests/test_dlpack_interop.py
+++ b/array_api_strict/tests/test_dlpack_interop.py
@@ -1,0 +1,44 @@
+"""Check how other libraries see arrays of array_api_strict via DLPack.
+
+Tests that libraries like NumPy and PyTorch can import arrays from
+array_api_strict via DLPack.
+
+Only run if torch is available.
+"""
+import numpy as np
+import pytest
+
+import array_api_strict as xp
+from .._devices import ALL_DEVICES, CPU_DEVICE
+
+torch = pytest.importorskip("torch")
+
+
+def test_export_from_cpu_device():
+    x = xp.asarray([1, 2, 3], device=CPU_DEVICE)
+
+    assert np.from_dlpack(x).tolist() == [1, 2, 3]
+    assert torch.from_dlpack(x).tolist() == [1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "device", [device for device in ALL_DEVICES if device != CPU_DEVICE]
+)
+def test_export_from_other_devices(device):
+    x = xp.asarray([1, 2, 3], device=device)
+
+    with pytest.raises(BufferError):
+        np.from_dlpack(x)
+    with pytest.raises(BufferError):
+        torch.from_dlpack(x)
+
+    assert torch.from_dlpack(x.to_device(CPU_DEVICE)).tolist() == [1, 2, 3]
+
+
+@pytest.mark.parametrize("device", ALL_DEVICES)
+def test_import_from_torch(device):
+    # int32 is the widest integer every device supports
+    x = xp.from_dlpack(torch.asarray([1, 2, 3], dtype=torch.int32), device=device)
+
+    assert x.device == device
+    assert xp.all(x == xp.asarray([1, 2, 3], dtype=xp.int32, device=device))


### PR DESCRIPTION
This improves the `from_dlpack` behaviour for round-tripping array-api-strict arrays and raises an error for arrays that are not on the CPU device.

This is a follow up to #219 and #221 

We use the device ID to tell the difference between the different "devices" present in array-api-strict. This seems to work/not bother libraries like torch or numpy. The device type is always CPU. In #212 we tried using different device type IDs, but that turns out not to work. I think the standard says (or suggests?) that for the CPU device the only device ID that makes sense is zero. In practice it seems every library ignores this field for CPU devices. Originally I thought we needed to use different device IDs to be able to make the following code work:
```python
x = asarray([1, 2, 3], device=device)
y = from_dlpack(x)
assert y.device == device
```
Before this PR the assert will fail.

But, now we have a `isinstance(x, Array)` branch in `from_dlpack` (line 257 of `array_api_strict/_creation_functions.py`). So we could do some special casing in this `if` statement. That way we don't have to report IDs that are not part of the standard. The downside is that `__dlpack_device__` would report the same for all the devices in array-api-strict. I can't make up my mind which option I prefer.

On `main` it is possible to "transfer" a device from `"device1"` to the CPU by using `np.from_dlpack(x_on_device1)`. This is explicitly not allowed when using `np.asarray()`. This PR adjusts the DLPack behaviour to match the `__buffer__` based behaviour.

This also installs torch for one of the CI jobs to test DLpack'ing arrays to and from a different library.