### PR TITLE
MAINT: Ignoring git blame for automatic ruff formats

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# MAINT: Ruff `safe-fixes` (#235)
+aa33a42e39cd278a4f51ac0507b493c3d543074d
+
+# MAINT: Adding ruff unsafe-fixes (#236)
+6558d184b48c626c89ced8e35d4431f75b3a3d06


### PR DESCRIPTION
Mentioned [here](https://github.com/data-apis/array-api-strict/issues/228#issuecomment-5129216100)

Related to: #228 